### PR TITLE
Implement get_all_teams() to return all teams

### DIFF
--- a/frameioclient/client.py
+++ b/frameioclient/client.py
@@ -32,12 +32,23 @@ class FrameioClient(object):
 
   def get_teams(self, account_id):
     """
-    Get teams owned by the account.
-
+    Get teams owned by the account. 
+    (To return all teams, use get_all_teams())
+    
     :Args:
       account_id (string): The account id.
     """
     endpoint = '/accounts/{}/teams'.format(account_id)
+    return self._api_call('get', endpoint)
+  
+  def get_all_teams(self, account_id):
+    """
+    Get all teams owned by the account.
+
+    :Args:
+      account_id (string): The account id.
+    """
+    endpoint = '/teams/{}'.format(account_id)
     return self._api_call('get', endpoint)
   
   def get_projects(self, team_id):

--- a/frameioclient/client.py
+++ b/frameioclient/client.py
@@ -41,14 +41,14 @@ class FrameioClient(object):
     endpoint = '/accounts/{}/teams'.format(account_id)
     return self._api_call('get', endpoint)
   
-  def get_all_teams(self, account_id):
+  def get_all_teams(self):
     """
-    Get all teams owned by the account.
+    Get all teams for the authenticated user.
 
     :Args:
       account_id (string): The account id.
     """
-    endpoint = '/teams/{}'.format(account_id)
+    endpoint = '/teams'
     return self._api_call('get', endpoint)
   
   def get_projects(self, team_id):


### PR DESCRIPTION
I think this should work based on what we talked about in Slack, but it is untested so if you have a dev environment - it's worth running it through that first. Also, feel free to adjust the copy I added to the `get_teams()` method talking about `get_all_teams()`.