### PR TITLE
WIP Fix uploading in Python 3.8+

### DIFF
--- a/frameioclient/upload.py
+++ b/frameioclient/upload.py
@@ -1,6 +1,11 @@
-from multiprocessing import Process
 import requests
 import math
+import sys
+
+if sys.version_info.major == 3 and sys.version_info.minor == 8:
+  from multiprocessing_on_dill import Process
+else:
+  from multiprocessing import Process
 
 class FrameioUploader(object):
   def __init__(self, asset, file):

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,9 @@ with open("README.md", "r") as f:
 setuptools.setup(
   name='frameioclient',
   version='0.6.0',
+  install_requires=[
+      "multiprocessing_on_dill",
+  ],
   description='Client library for the Frame.io API',
   long_description=long_description,
   long_description_content_type="text/markdown",


### PR DESCRIPTION
This is a pretty naive solution right now, and my goal is to replace the call to multiprocessing with asyncio instead on 3.8+ (and potentially older versions as well).