### PR TITLE
Remove python 3.6.x installation blocker

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ class VerifyVersionCommand(install):
 setuptools.setup(
   name='frameioclient',
   version=version,
-  python_requires='>=2.7.17, !=3.6.*, <4',
+  python_requires='>=2.7.17, <4',
   install_requires=[
     'requests',
     'urllib3',


### PR DESCRIPTION
We should add some more test coverage for some 3.6.x python versions, but removing this blocker shouldn't cause any issues.