### PR TITLE
Actually use xxHash for upload QC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,6 @@ workflows:
     triggers:
       - schedule:
           cron: "0,30 * * * *"
-          # cron: "0 0 * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ workflows:
     jobs:
       - build
 
-      - linux_py_latest:
+      - upload_test_job:
           requires:
             - build
 
@@ -159,6 +159,27 @@ jobs:
           name: Run integration test
           command: |
             python /tmp/artifact/tests/integration.py
+
+  upload_test_job:
+    description: Upload test
+    docker:
+      - image: circleci/python:latest
+
+    steps:
+      - attach_workspace:
+          at: /tmp/artifact
+          name: Attach build artifact
+
+      - run:
+          name: Install package
+          command: |
+            pip install '/tmp/artifact'
+
+      - run:
+          name: Run integration test
+          command: |
+            python /tmp/artifact/tests/integration.py
+
 
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,11 +39,28 @@ workflows:
               only:
                 - master
             tags:
-                only: /[0-9]+(\.[0-9]+)*/
+              only: /[0-9]+(\.[0-9]+)*/
 
       - deploy:
           requires:
             - hold
+
+  upload_test:
+    triggers:
+      - schedule:
+          cron: "0,30 * * * *"
+          # cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - jh/use-xxhash-for-integration-test
+
+    jobs:
+      - build
+
+      - linux_py_latest:
+          requires:
+            - build
 
 jobs:
   build:
@@ -144,10 +161,9 @@ jobs:
           command: |
             python /tmp/artifact/tests/integration.py
 
-
   deploy:
     docker:
-    - image: circleci/python:latest
+      - image: circleci/python:latest
 
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,21 +45,21 @@ workflows:
           requires:
             - hold
 
-  upload_test:
-    triggers:
-      - schedule:
-          cron: "0,30 * * * *"
-          filters:
-            branches:
-              only:
-                - jh/use-xxhash-for-integration-test
+  # upload_test:
+  #   triggers:
+  #     - schedule:
+  #         cron: "0,30 * * * *"
+  #         filters:
+  #           branches:
+  #             only:
+  #               - jh/use-xxhash-for-integration-test
 
-    jobs:
-      - build
+  #   jobs:
+  #     - build
 
-      - upload_test_job:
-          requires:
-            - build
+  #     - upload_test_job:
+  #         requires:
+  #           - build
 
 jobs:
   build:

--- a/frameioclient/py3_uploader.py
+++ b/frameioclient/py3_uploader.py
@@ -27,10 +27,12 @@ class FrameioUploader(object):
     chunk = task[1]
     session = self._get_session()
 
-    session.put(url, data=chunk, headers={
+    r = session.put(url, data=chunk, headers={
       'content-type': self.asset['filetype'],
       'x-amz-acl': 'private'
     })
+
+    r.raise_for_status()
 
   def upload(self):
     total_size = self.asset['filesize']

--- a/frameioclient/py3_uploader.py
+++ b/frameioclient/py3_uploader.py
@@ -28,7 +28,6 @@ class FrameioUploader(object):
     session = self._get_session()
 
     try:
-        
       r = session.put(url, data=chunk, headers={
         'content-type': self.asset['filetype'],
         'x-amz-acl': 'private'

--- a/frameioclient/py3_uploader.py
+++ b/frameioclient/py3_uploader.py
@@ -27,10 +27,16 @@ class FrameioUploader(object):
     chunk = task[1]
     session = self._get_session()
 
-    r = session.put(url, data=chunk, headers={
-      'content-type': self.asset['filetype'],
-      'x-amz-acl': 'private'
-    })
+    try:
+        
+      r = session.put(url, data=chunk, headers={
+        'content-type': self.asset['filetype'],
+        'x-amz-acl': 'private'
+      })
+
+    except Exception as e:
+      print(e)
+      r.raise_for_status()
 
     r.raise_for_status()
 

--- a/frameioclient/utils.py
+++ b/frameioclient/utils.py
@@ -50,7 +50,7 @@ def calculate_hash(file_path):
             break
         xxh64_hash.update(b[:numread])
 
-    xxh64_digest = xxh64_hash.hexdigest()
+    xxh64_digest = xxh64_hash.hexdigest().encode()
 
     return xxh64_digest
 

--- a/frameioclient/utils.py
+++ b/frameioclient/utils.py
@@ -50,7 +50,7 @@ def calculate_hash(file_path):
             break
         xxh64_hash.update(b[:numread])
 
-    xxh64_digest = xxh64_hash.hexdigest().encode()
+    xxh64_digest = xxh64_hash.hexdigest()
 
     return xxh64_digest
 

--- a/frameioclient/utils.py
+++ b/frameioclient/utils.py
@@ -1,3 +1,6 @@
+import xxhash
+import sys
+
 def stream(func, page=1, page_size=20):
     """
     Accepts a lambda of a call to a client list method, and streams the results until
@@ -17,3 +20,53 @@ def stream(func, page=1, page_size=20):
             yield res
 
         page += 1
+
+KB = 1024
+MB = KB * KB
+
+def format_bytes(size):
+    """Convert bytes to KB/MB/GB/TB/s
+    """
+    # 2**10 = 1024
+    power = 2**10
+    n = 0
+    power_labels = {0 : 'B/s', 1: 'KB/s', 2: 'MB/s', 3: 'GB/s', 4: 'TB/s'}
+    while size > power:
+        size /= power
+        n += 1
+    return " ".join((str(round(size, 2)), power_labels[n]))
+
+
+def calculate_hash(file_path):
+    """Calculate an xx64hash
+    """
+    xxh64_hash = xxhash.xxh64()
+    b = bytearray(MB * 8)
+    f = open(file_path, "rb")
+    while True:
+        numread = f.readinto(b)
+        if not numread:
+            break
+        xxh64_hash.update(b[:numread])
+
+    xxh64_digest = xxh64_hash.hexdigest()
+
+    return xxh64_digest
+
+def compare_items(dict1, dict2):
+    """Python 2 and 3 compatible way of comparing 2x dictionaries
+    """
+    if sys.version_info.major >= 3:
+        import operator
+        comparison = operator.eq(dict1, dict2)
+        
+        if comparison == False:
+            print("File mismatch between upload and download")
+            sys.exit(1)
+
+    else:
+        # Use different comparsion function in < Py3
+        comparison = cmp(dict1, dict2)
+        if comparison != 0:
+            print("File mismatch between upload and download")
+            sys.exit(1)

--- a/frameioclient/utils.py
+++ b/frameioclient/utils.py
@@ -1,6 +1,9 @@
 import xxhash
 import sys
 
+KB = 1024
+MB = KB * KB
+
 def stream(func, page=1, page_size=20):
     """
     Accepts a lambda of a call to a client list method, and streams the results until
@@ -21,9 +24,6 @@ def stream(func, page=1, page_size=20):
 
         page += 1
 
-KB = 1024
-MB = KB * KB
-
 def format_bytes(size):
     """Convert bytes to KB/MB/GB/TB/s
     """
@@ -31,11 +31,12 @@ def format_bytes(size):
     power = 2**10
     n = 0
     power_labels = {0 : 'B/s', 1: 'KB/s', 2: 'MB/s', 3: 'GB/s', 4: 'TB/s'}
+
     while size > power:
         size /= power
         n += 1
-    return " ".join((str(round(size, 2)), power_labels[n]))
 
+    return " ".join((str(round(size, 2)), power_labels[n]))
 
 def calculate_hash(file_path):
     """Calculate an xx64hash
@@ -56,17 +57,19 @@ def calculate_hash(file_path):
 def compare_items(dict1, dict2):
     """Python 2 and 3 compatible way of comparing 2x dictionaries
     """
+    comparison = None
+
     if sys.version_info.major >= 3:
         import operator
         comparison = operator.eq(dict1, dict2)
         
-        if comparison == False:
-            print("File mismatch between upload and download")
-            sys.exit(1)
-
     else:
         # Use different comparsion function in < Py3
         comparison = cmp(dict1, dict2)
         if comparison != 0:
-            print("File mismatch between upload and download")
-            sys.exit(1)
+            comparison = False # Set it to false so that it matches above ^
+
+    if comparison == False:
+        print("File mismatch between upload and download")
+
+    return comparison

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setuptools.setup(
   install_requires=[
     'requests',
     'urllib3',
+    'xxhash',
     'importlib-metadata ~= 1.0 ; python_version < "3.8"',
   ],
   extras_require={

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -240,9 +240,9 @@ def check_upload_completion(client, download_folder_id, upload_folder_id):
     print("Verification complete for {}/{} uploaded assets.".format(int(len(ul_items)), int(len(dl_items))))
 
     if ci_job_name is not None:
+        print("CircleCI Job Name: {}".format(ci_job_name))
         if ci_job_name == "upload_test_job":
             send_to_slack(format_slack_message(pass_fail, ul_items, dl_items))
-    
 
     if pass_fail == True:
         print("Integration test passed! :)")

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -167,9 +167,18 @@ def flatten_asset_children(asset_children):
 
     return flat_dict
 
-def check_for_checksums(asset_children):
+def check_for_checksums(client, upload_folder_id):
+    # Get asset children for upload folder
+    asset_children = client.get_asset_children(
+        upload_folder_id,
+        page=1,
+        page_size=40,
+        include="children"
+    )
+
     global retries
     print("Checking for checksums attempt #{}".format(retries+1))
+    
     if retries < 4:
         for asset in asset_children:
             try:
@@ -187,7 +196,7 @@ def check_for_checksums(asset_children):
                 print("Checksums not yet calculated, sleeping for 15 seconds.")
                 time.sleep(15)
                 retries += 1
-                check_for_checksums(asset_children)
+                check_for_checksums(client, upload_folder_id)
         return True
     else:
         return False
@@ -219,7 +228,7 @@ def check_upload_completion(client, download_folder_id, upload_folder_id):
     print("Got asset children for uploaded folder")
 
     print("Making sure checksums are calculated before verifying")
-    check_for_checksums(ul_asset_children)
+    check_for_checksums(client, upload_folder_id)
 
     dl_items = flatten_asset_children(dl_asset_children)
     ul_items = flatten_asset_children(ul_asset_children)

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -179,7 +179,7 @@ def check_for_checksums(client, upload_folder_id):
     global retries
     print("Checking for checksums attempt #{}".format(retries+1))
     
-    if retries < 40:
+    if retries < 20:
         for asset in asset_children:
             try:
                 asset['checksums']['xx_hash']
@@ -217,6 +217,9 @@ def check_upload_completion(client, download_folder_id, upload_folder_id):
 
     print("Got asset children for original download folder")
 
+    print("Making sure checksums are calculated before verifying")
+    check_for_checksums(client, upload_folder_id)
+
     # Get asset children for upload folder
     ul_asset_children = client.get_asset_children(
         upload_folder_id,
@@ -226,9 +229,6 @@ def check_upload_completion(client, download_folder_id, upload_folder_id):
     )
 
     print("Got asset children for uploaded folder")
-
-    print("Making sure checksums are calculated before verifying")
-    check_for_checksums(client, upload_folder_id)
 
     dl_items = flatten_asset_children(dl_asset_children)
     ul_items = flatten_asset_children(ul_asset_children)

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -132,7 +132,7 @@ def check_upload_completion(client, download_folder_id, upload_folder_id):
 
     for asset in ul_asset_children:
         try:
-            asset.get('checksums')
+            asset['checksums']['xx_hash']
         except TypeError:
             print("Checksums not yet calculated, sleeping")
             time.sleep(10)

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -267,8 +267,6 @@ def check_upload_completion(client, download_folder_id, upload_folder_id):
 
     print("Verification complete for {}/{} uploaded assets.".format(int(len(ul_items)), int(len(og_items))))
 
-    ci_job_name = "upload_test_job"
-
     if ci_job_name is not None:
         print("CircleCI Job Name: {}".format(ci_job_name))
         if ci_job_name == "upload_test_job":

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -110,7 +110,8 @@ def flatten_asset_children(asset_children):
 
 
 def check_for_checksums(asset_children):
-    while i <= 10:
+    i = 0
+    while i < 10:
         for asset in asset_children:
             try:
                 asset['checksums']['xx_hash']

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -168,6 +168,7 @@ def check_for_checksums(asset_children):
                 print("Checksums not yet calculated, sleeping for 5 seconds.")
                 time.sleep(15)
                 retries += 1
+                check_for_checksums(asset_children)
 
         return True
     else:

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -110,25 +110,26 @@ def flatten_asset_children(asset_children):
 
 
 def check_for_checksums(asset_children):
-    for i in range(10):
-        while i <= 10:
-            for asset in asset_children:
-                try:
-                    asset['checksums']['xx_hash']
-                    print("Success..")
-                    print("Checksum dict: ")
-                    pprint(asset['checksums'])
-                    print("\n")
-                except TypeError:
-                    print("Failure...")
-                    print("Checksum dict \n")
-                    pprint(asset['checksums'])
-                    print("Asset ID: {}".format(asset['id']))
-                    print("Asset Name: {}".format(asset['name']))
-                    print("Checksums not yet calculated, sleeping for 10 seconds.")
-                    time.sleep(5)
-                    i += 1
-                    continue
+    while i <= 10:
+        for asset in asset_children:
+            try:
+                asset['checksums']['xx_hash']
+                print("Success..")
+                print("Asset ID: {}".format(asset['id']))
+                print("Asset Name: {}".format(asset['name']))
+                print("Checksum dict: ")
+                pprint(asset['checksums'])
+                print("\n")
+            except TypeError:
+                print("Failure...")
+                print("Checksum dict:")
+                pprint(asset['checksums'])
+                print("Asset ID: {}".format(asset['id']))
+                print("Asset Name: {}".format(asset['name']))
+                print("Checksums not yet calculated, sleeping for 5 seconds.")
+                time.sleep(5)
+                i += 1
+                continue
 
     return True
 

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -75,7 +75,7 @@ def format_bytes(size):
     # 2**10 = 1024
     power = 2**10
     n = 0
-    power_labels = {0 : '', 1: 'KB/s', 2: 'MB/s', 3: 'GB/s', 4: 'TB/s'}
+    power_labels = {0 : 'B/s', 1: 'KB/s', 2: 'MB/s', 3: 'GB/s', 4: 'TB/s'}
     while size > power:
         size /= power
         n += 1

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -54,7 +54,7 @@ def verify_local(client, dl_children):
         print("Path to downloaded file for hashing: {}".format(dl_file_path))
         xxhash = calculate_hash(dl_file_path)
         xxhash_name = "{}_{}".format(fn, 'xxHash')
-        dl_items[xxhash_name] = xxhash
+        dl_items[xxhash_name] = xxhash.decode("utf-8")
 
     print("QCing Downloaded Files...")
 
@@ -246,11 +246,14 @@ def check_upload_completion(client, download_folder_id, upload_folder_id):
     print("Got asset children for uploaded folder")
 
     global dl_items # Get the global dl_items
+
+    # if len(dl_items.items) < 1:
+
     og_items = flatten_asset_children(dl_asset_children)
     ul_items = flatten_asset_children(ul_asset_children)
 
-    print("'Completed' uploads: {}/{}".format(int(len(ul_items)), int(len(dl_items))))
-    print("Percentage uploads completed but not verified: {:.2%}".format(len(ul_items)/len(dl_items)))
+    print("'Completed' uploads: {}/{}".format(int(len(ul_items)), int(len(og_items))))
+    print("Percentage uploads completed but not verified: {:.2%}".format(len(ul_items)/len(og_items)))
 
     print("Running verification...")
 

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -111,7 +111,7 @@ def flatten_asset_children(asset_children):
 
 def check_for_checksums(asset_children):
     for i in range(10):
-        while True:
+        while i <= 10:
             for asset in asset_children:
                 try:
                     asset['checksums']['xx_hash']
@@ -127,8 +127,8 @@ def check_for_checksums(asset_children):
                     print("Asset Name: {}".format(asset['name']))
                     print("Checksums not yet calculated, sleeping for 10 seconds.")
                     time.sleep(5)
+                    i += 1
                     continue
-                break
 
     return True
 

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -179,7 +179,7 @@ def check_for_checksums(client, upload_folder_id):
     global retries
     print("Checking for checksums attempt #{}".format(retries+1))
     
-    if retries < 16:
+    if retries < 40:
         for asset in asset_children:
             try:
                 asset['checksums']['xx_hash']

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -12,9 +12,9 @@ from pprint import pprint
 from datetime import datetime
 from frameioclient import FrameioClient
 
-token = os.getenv("FRAMEIO_TOKEN")
-project_id = os.getenv("PROJECT_ID")
-download_asset_id = os.getenv("DOWNLOAD_FOLDER_ID")
+token = os.getenv("FRAMEIO_TOKEN") # Your Frame.io token
+project_id = os.getenv("PROJECT_ID") # Project you want to upload files back into
+download_asset_id = os.getenv("DOWNLOAD_FOLDER_ID") # Source folder on Frame.io (to then verify against)
 
 retries = 0
 

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -109,7 +109,11 @@ def check_for_checksums(asset_children):
     for asset in asset_children:
         try:
             asset['checksums']['xx_hash']
+            print("Success..")
+            print("Checksum dict \n")
+            pprint(asset['checksums'])
         except TypeError:
+            print("Failure...")
             print("Checksum dict \n")
             pprint(asset['checksums'])
             print("Asset ID: {}".format(asset['id']))

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -110,6 +110,10 @@ def check_for_checksums(asset_children):
         try:
             asset['checksums']['xx_hash']
         except TypeError:
+            print("Checksum dict \n")
+            pprint(asset['checksums'])
+            print("Asset ID: {}".format(asset['id']))
+            print("Asset Name: {}".format(asset['name']))
             print("Checksums not yet calculated, sleeping for 10 seconds.")
             time.sleep(10)
             check_for_checksums(asset_children)

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -151,6 +151,7 @@ def flatten_asset_children(asset_children):
 
 def check_for_checksums(asset_children):
     global retries
+    print("Checking for checksums attempt #{}".format(retries+1))
     if retries < 4:
         for asset in asset_children:
             try:
@@ -165,11 +166,10 @@ def check_for_checksums(asset_children):
                 print("Checksum dict: {}".format(asset['checksums']))
                 print("Asset ID: {}".format(asset['id']))
                 print("Asset Name: {}".format(asset['name']))
-                print("Checksums not yet calculated, sleeping for 5 seconds.")
+                print("Checksums not yet calculated, sleeping for 15 seconds.")
                 time.sleep(15)
                 retries += 1
                 check_for_checksums(asset_children)
-
         return True
     else:
         return False

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -54,7 +54,7 @@ def verify_local(client, dl_children):
         print("Path to downloaded file for hashing: {}".format(dl_file_path))
         xxhash = calculate_hash(dl_file_path)
         xxhash_name = "{}_{}".format(fn, 'xxHash')
-        dl_items[xxhash_name] = xxhash.decode("utf-8")
+        dl_items[xxhash_name] = xxhash.decode("utf-8").encode("utf-8")
 
     print("QCing Downloaded Files...")
 
@@ -173,7 +173,8 @@ def flatten_asset_children(asset_children):
     for asset in asset_children:
         try:
             xxhash_name = "{}_{}".format(asset['name'], 'xxHash')
-            flat_dict[xxhash_name] = asset['checksums']['xx_hash']
+            flat_dict[xxhash_name] = asset['checksums']['xx_hash'].encode("utf-8")
+
         except TypeError:
             xxhash_name = "{}_{}".format(asset['name'], 'xxHash')
             flat_dict[xxhash_name] = "missing"

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -179,7 +179,7 @@ def check_for_checksums(client, upload_folder_id):
     global retries
     print("Checking for checksums attempt #{}".format(retries+1))
     
-    if retries < 4:
+    if retries < 16:
         for asset in asset_children:
             try:
                 asset['checksums']['xx_hash']

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -97,30 +97,38 @@ def flatten_asset_children(asset_children):
     flat_dict = dict()
 
     for asset in asset_children:
-        size_name = "{}-{}".format(asset['name'], 'size')
-        flat_dict[size_name] = asset['filesize']
+        try:
+            size_name = "{}-{}".format(asset['name'], 'size')
+            flat_dict[size_name] = asset['filesize']
 
-        xxhash_name = "{}-{}".format(asset['name'], 'xxHash')
-        flat_dict[xxhash_name] = asset['checksums']['xx_hash']
+            xxhash_name = "{}-{}".format(asset['name'], 'xxHash')
+            flat_dict[xxhash_name] = asset['checksums']['xx_hash']
+        except TypeError:
+            continue
 
     return flat_dict
 
+
 def check_for_checksums(asset_children):
-    for asset in asset_children:
-        try:
-            asset['checksums']['xx_hash']
-            print("Success..")
-            print("Checksum dict \n")
-            pprint(asset['checksums'])
-        except TypeError:
-            print("Failure...")
-            print("Checksum dict \n")
-            pprint(asset['checksums'])
-            print("Asset ID: {}".format(asset['id']))
-            print("Asset Name: {}".format(asset['name']))
-            print("Checksums not yet calculated, sleeping for 10 seconds.")
-            time.sleep(10)
-            check_for_checksums(asset_children)
+    for i in range(10):
+        while True:
+            for asset in asset_children:
+                try:
+                    asset['checksums']['xx_hash']
+                    print("Success..")
+                    print("Checksum dict: ")
+                    pprint(asset['checksums'])
+                    print("\n")
+                except TypeError:
+                    print("Failure...")
+                    print("Checksum dict \n")
+                    pprint(asset['checksums'])
+                    print("Asset ID: {}".format(asset['id']))
+                    print("Asset Name: {}".format(asset['name']))
+                    print("Checksums not yet calculated, sleeping for 10 seconds.")
+                    time.sleep(5)
+                    continue
+                break
 
     return True
 
@@ -154,6 +162,9 @@ def check_upload_completion(client, download_folder_id, upload_folder_id):
 
     dl_items = flatten_asset_children(dl_asset_children)
     ul_items = flatten_asset_children(ul_asset_children)
+
+    print("Valid uploads: {}/{}".format(len(ul_items), len(dl_items)))
+    print("Percentage uploads valid: {:.2%}".format(len(ul_items)/len(dl_items)))
 
     print("Running comparison...")
 

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -125,8 +125,8 @@ def test_upload(client):
 
         print("{}/{} Upload completed in {:.2f}s @ {}".format((count), len(dled_files), upload_time, upload_speed))
 
-    print("Sleeping for 5 seconds to allow uploads to finish...")
-    time.sleep(5)
+    print("Sleeping for 30 seconds to allow upload and media analysis to finish...")
+    time.sleep(30)
 
     print("Continuing...")
 

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -3,7 +3,7 @@ import sys
 import json
 import time
 import socket
-import xxhash
+# import xxhash
 import platform
 import mimetypes
 

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -106,7 +106,7 @@ def flatten_asset_children(asset_children):
     return flat_dict
 
 def check_for_checksums(asset_children):
-    for asset in ul_asset_children:
+    for asset in asset_children:
         try:
             asset['checksums']['xx_hash']
         except TypeError:

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -20,6 +20,7 @@ project_id = os.getenv("PROJECT_ID") # Project you want to upload files back int
 download_asset_id = os.getenv("DOWNLOAD_FOLDER_ID") # Source folder on Frame.io (to then verify against)
 environment = os.getenv("ENVIRONMENT", default="PRODUCTION")
 slack_webhook_url = os.getenv("SLACK_WEBHOOK_URL")
+ci_job_name = os.getenv("CIRCLE_JOB", default=None)
 
 retries = 0
 
@@ -238,7 +239,10 @@ def check_upload_completion(client, download_folder_id, upload_folder_id):
 
     print("Verification complete for {}/{} uploaded assets.".format(int(len(ul_items)), int(len(dl_items))))
 
-    send_to_slack(format_slack_message(pass_fail, ul_items, dl_items))
+    if ci_job_name is not None:
+        if ci_job_name == "upload_test_job":
+            send_to_slack(format_slack_message(pass_fail, ul_items, dl_items))
+    
 
     if pass_fail == True:
         print("Integration test passed! :)")

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -96,7 +96,11 @@ def flatten_asset_children(asset_children):
     flat_dict = dict()
 
     for asset in asset_children:
-        flat_dict[asset['name']] = asset['filesize']
+        size_name = "{}-{}".format(asset['name'],'size')
+        flat_dict[size_name] = asset['filesize']
+
+        xxhash_name = "{}-{}".format(asset['name'], 'xxHash')
+        flat_dict[xxhash_name] = asset['checksums']['xx_hash']
 
     return flat_dict
 
@@ -125,6 +129,14 @@ def check_upload_completion(client, download_folder_id, upload_folder_id):
     )
 
     print("Got asset children for uploaded folder")
+
+    for asset in ul_asset_children:
+        try:
+            asset.get('checksums')
+        except TypeError:
+            print("Checksums not yet calculated, sleeping")
+            time.sleep(10)
+            check_upload_completion(client, download_folder_id, upload_folder_id)
 
     dl_items = flatten_asset_children(dl_asset_children)
     ul_items = flatten_asset_children(ul_asset_children)

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -54,7 +54,7 @@ def verify_local(client, dl_children):
         print("Path to downloaded file for hashing: {}".format(dl_file_path))
         xxhash = calculate_hash(dl_file_path)
         xxhash_name = "{}_{}".format(fn, 'xxHash')
-        dl_items[xxhash_name] = xxhash.decode("utf-8").encode("utf-8")
+        dl_items[xxhash_name] = xxhash
 
     print("QCing Downloaded Files...")
 
@@ -173,7 +173,7 @@ def flatten_asset_children(asset_children):
     for asset in asset_children:
         try:
             xxhash_name = "{}_{}".format(asset['name'], 'xxHash')
-            flat_dict[xxhash_name] = asset['checksums']['xx_hash'].encode("utf-8")
+            flat_dict[xxhash_name] = asset['checksums']['xx_hash']
 
         except TypeError:
             xxhash_name = "{}_{}".format(asset['name'], 'xxHash')


### PR DESCRIPTION
Closes DEVREL-370

When the integration test was first written, it didn’t take advantage of the xxHash field in asset responses. Now that it’s in production - we can actually use it!