### PR TITLE
Switch CircleCI to build matrix for different Python versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,29 +10,17 @@ workflows:
     jobs:
       - build
 
-      - linux_py_27_16:
+      - integration_test:
           requires:
             - build
-
-      - linux_py_27_latest:
-          requires:
-            - build
-
-      - linux_py_37:
-          requires:
-            - build
-
-      - linux_py_latest:
-          requires:
-            - build
+          matrix:
+            parameters:
+              python-version: ["2.7.16", "2.7.18", "latest", "3.7.7"]
 
       - hold:
           type: approval
           requires:
-            - linux_py_27_16
-            - linux_py_27_latest
-            - linux_py_37
-            - linux_py_latest
+            - integration_test
 
           filters:
             branches:
@@ -80,10 +68,10 @@ jobs:
           paths:
             - .
 
-  linux_py_27_16:
-    description: Linux 2.7.16
+  integration_test:
+    description: Python << parameters.node-version >>
     docker:
-      - image: circleci/python:2.7.16
+      - image: circleci/python:<< parameters.node-version >>
 
     steps:
       - attach_workspace:
@@ -94,66 +82,6 @@ jobs:
           name: Install package
           command: |
             pip install --user '/tmp/artifact'
-
-      - run:
-          name: Run integration test
-          command: |
-            python /tmp/artifact/tests/integration.py
-
-  linux_py_27_latest:
-    description: Linux 2.7.18
-    docker:
-      - image: circleci/python:2.7.18
-
-    steps:
-      - attach_workspace:
-          at: /tmp/artifact
-          name: Attach build artifact
-
-      - run:
-          name: Install package
-          command: |
-            pip install '/tmp/artifact'
-
-      - run:
-          name: Run integration test
-          command: |
-            python /tmp/artifact/tests/integration.py
-
-  linux_py_37:
-    description: Linux 3.7.7
-    docker:
-      - image: circleci/python:3.7.7
-
-    steps:
-      - attach_workspace:
-          at: /tmp/artifact
-          name: Attach build artifact
-
-      - run:
-          name: Install package
-          command: |
-            pip install '/tmp/artifact'
-
-      - run:
-          name: Run integration test
-          command: |
-            python /tmp/artifact/tests/integration.py
-
-  linux_py_latest:
-    description: Linux latest
-    docker:
-      - image: circleci/python:latest
-
-    steps:
-      - attach_workspace:
-          at: /tmp/artifact
-          name: Attach build artifact
-
-      - run:
-          name: Install package
-          command: |
-            pip install '/tmp/artifact'
 
       - run:
           name: Run integration test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,9 +69,13 @@ jobs:
             - .
 
   integration_test:
-    description: Python << parameters.node-version >>
+    parameters:
+      python-version:
+        type: string
+
+    description: Python << parameters.python-version >>
     docker:
-      - image: circleci/python:<< parameters.node-version >>
+      - image: circleci/python:<< parameters.python-version >>
 
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ workflows:
     jobs:
       - build
 
-      - integration_test:
+      - test_integration:
           requires:
             - build
           matrix:
@@ -20,7 +20,7 @@ workflows:
       - hold:
           type: approval
           requires:
-            - integration_test
+            - test_integration
 
           filters:
             branches:
@@ -68,7 +68,7 @@ jobs:
           paths:
             - .
 
-  integration_test:
+  test_integration:
     parameters:
       python-version:
         type: string


### PR DESCRIPTION
[DEVREL-270]

**What I'm doing:**

Switch to matrix builds in Circle CI to simplify the `config.yaml` file and make it easier to add new python versions.

[DEVREL-270]: https://frame-io.atlassian.net/browse/DEVREL-270