### PR TITLE
Rename the deprecated/removed urllib3 'method_whitelist' argument name in Retry()

### DIFF
--- a/frameioclient/lib/transport.py
+++ b/frameioclient/lib/transport.py
@@ -49,7 +49,7 @@ class HTTPClient(object):
             total=100,
             backoff_factor=2,
             status_forcelist=retryable_statuses,
-            method_whitelist=["GET", "POST", "PUT", "GET", "DELETE"],
+            allowed_methods=["GET", "POST", "PUT", "GET", "DELETE"],
         )
 
         # Create real thread


### PR DESCRIPTION
## [DEVREL-XXXX]

### Description:
Renames the [deprecated & removed](https://github.com/urllib3/urllib3/pull/2086) urllib3 `method_whitelist` arg name to `allowed_methods`.

### Depends on:
None

### Includes changes from:
None

### I'd like feedback on:
None
