### PR TITLE
Fixed the name of parameter ``method_whitelist`` since it was changed

### DIFF
--- a/frameioclient/lib/transport.py
+++ b/frameioclient/lib/transport.py
@@ -49,7 +49,7 @@ class HTTPClient(object):
             total=100,
             backoff_factor=2,
             status_forcelist=retryable_statuses,
-            method_whitelist=["GET", "POST", "PUT", "GET", "DELETE"],
+            allowed_methods=["GET", "POST", "PUT", "GET", "DELETE"],
         )
 
         # Create real thread

--- a/frameioclient/lib/transport.py
+++ b/frameioclient/lib/transport.py
@@ -45,12 +45,20 @@ class HTTPClient(object):
         self.shared_headers = {"x-frameio-client": f"python/{self.client_version}"}
 
         # Configure retry strategy (very broad right now)
-        self.retry_strategy = Retry(
-            total=100,
-            backoff_factor=2,
-            status_forcelist=retryable_statuses,
-            allowed_methods=["GET", "POST", "PUT", "GET", "DELETE"],
-        )
+        try:
+            self.retry_strategy = Retry(
+                total=100,
+                backoff_factor=2,
+                status_forcelist=retryable_statuses,
+                allowed_methods=["GET", "POST", "PUT", "GET", "DELETE"],
+            )
+        except TypeError:  # to save compatibility with older versions of urllib3
+            self.retry_strategy = Retry(
+                total=100,
+                backoff_factor=2,
+                status_forcelist=retryable_statuses,
+                method_whitelist=["GET", "POST", "PUT", "GET", "DELETE"],
+            )
 
         # Create real thread
         self._initialize_thread()


### PR DESCRIPTION
### Description:
The class **urllib3.util.retry.Retry** no longer has the ``method_whitelist`` parameter. It was renamed to **allowed_methods**.

From urllib3 documentation:

```
Previously this parameter was named ``method_whitelist``, that usage is deprecated in v1.26.0 and will be removed in v2.0.
```

[method_whitelist is deprecated](https://github.com/urllib3/urllib3/issues/2092) and already removed in latest versions of urllib3.
